### PR TITLE
Added docker support for the MySQL database

### DIFF
--- a/Setup/DB_setup.sql
+++ b/Setup/DB_setup.sql
@@ -1,4 +1,0 @@
-CREATE USER 'ippr'@'localhost' IDENTIFIED BY 'Pa$$w0rd';
-GRANT ALL PRIVILEGES ON * . * TO 'ippr'@'localhost';
-FLUSH PRIVILEGES;
-

--- a/Setup/mysql_docker/DB_setup.sql
+++ b/Setup/mysql_docker/DB_setup.sql
@@ -1,0 +1,11 @@
+-- Create databases which are not automatically created out of the code
+CREATE DATABASE ippr;
+CREATE DATABASE ippr_security;
+
+-- Create User for the services to access the DB
+CREATE USER 'ippr'@'localhost' IDENTIFIED BY 'Pa$$w0rd';
+GRANT ALL PRIVILEGES ON * . * TO 'ippr'@'localhost';
+CREATE USER 'ippr'@'%' IDENTIFIED BY 'Pa$$w0rd';
+GRANT ALL PRIVILEGES ON * . * TO 'ippr'@'%';
+FLUSH PRIVILEGES;
+

--- a/Setup/mysql_docker/Dockerfile
+++ b/Setup/mysql_docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM mysql:latest
+MAINTAINER Bajric (amar.bajric@edu.fh-joanneum.at)
+ENV MYSQL_ROOT_PASSWORD="Pa$$w0rd"
+RUN apt-get update
+# check https://hub.docker.com/_/mysql/ for more info about this directory
+COPY ./DB_setup.sql /docker-entrypoint-initdb.d/DB_setup.sql
+# This .sh file is only needed for extra configuration. Not needed for basic set-up.
+# COPY ./configure_mysql_docker.sh /docker-entrypoint-initdb.d/configure_mysql_docker.sh

--- a/Setup/mysql_docker/configure_mysql_docker.sh
+++ b/Setup/mysql_docker/configure_mysql_docker.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# -- Is needed for replacing the bind-address but for local usage it is not needed --
+
+# cd /etc/mysql/mysql.conf.d
+# sleep 0.02
+# sed -i -- 's/#bind-address[[:blank:]]*=[[:blank:]]*127.0.0.1/bind-address=0.0.0.0/g' mysqld.cnf
+# sleep 0.02
+# service mysql restart

--- a/Setup/mysql_docker/docker-compose.yml
+++ b/Setup/mysql_docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  mysql:
+    container_name: ebusa-mysql
+    build: .
+    ports:
+     - "3306:3306"
+    restart: always
+


### PR DESCRIPTION
resolves #4 

**Done:**
- added new folder in Setup directory for mysql-docker
- added `Dockerfile` for creating custom image and including `DB_setup.sql` file
- modified and moved `DB_setup.sql` file
- building mysql image, running container and executing `DB_setup.sql` file automatically
- added `docker-compose.yml` file to automatically build image and set-up mysql docker container

**ToDo:**
- Test the mysql docker container:
  - `cd` into the `/Setup/mysql_docker` directory
  - run `docker-compose up` (or `docker-compose up -d` to truncate output) in your terminal
  - start all services and check if they can reach the database running in the docker container
- Include instructions into README (will be done by @amarbajric)