### PR TITLE
Update of README and both startup scripts

### DIFF
--- a/ProcessModelStorage/src/main/resources/application.properties
+++ b/ProcessModelStorage/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.port=0
 
+# If set to TRUE, it will enable the example and insert one process automatically in the db
+# If set to FALSE, it will disable the example and start the service(s) and db without an example-process
 ippr.insert-examples.enabled=true
 
 logging.level.at.fhjoanneum=DEBUG
@@ -11,7 +13,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/ippr?useSSL=false&createDataba
 spring.datasource.username=ippr
 spring.datasource.password=Pa$$w0rd
 spring.jpa.show-sql=false
+# Enable the following line if 'ippr.insert-examaples.enabled' is set to FALSE
 #spring.jpa.hibernate.ddl-auto=update
+# Enable the following line if 'ippr.insert-examples.enabled' is set to TRUE
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy

--- a/README.md
+++ b/README.md
@@ -1,202 +1,226 @@
-# S-BPM Modelling and Execution Platform #
 
-This is a modelling and execution platform for S-BPM processes, based on microservices powered by Spring Boot. The modelling platform is based on Angular 1, the frontend for the execution platform, however, is based on Angular 2.
-Basically, the platform consists of the following modules:
- - **ServiceDiscovery:** Automatic detection of devices and services.
- - **ConfigurationService:** Central repository for configuration files.
- - **ProcessModelStorage:** This is the process repository.
- - **ProcessEngine:** Responsible for the execution of processes, based on Akka.
- - **EventLogger:** Logs events during execution, exports logs in CSV format, manipulates PNML files and transforms manipulated PNML files to OWL files.
- - **Gateway:** Authentication and authorization service and handles the requests of the process execution frontend (GUI).
- - **Persistence:** Hibernate mapping of the database tables.
- - **ExternalCommunicator:** For the support of external projects.
- - **GUI-Dev:** Development project for the Angular 2 execution platform frontend (With some dev tools, with node server backend).
- - **GUI:** Production project for the Angular 2 execution platform frontend (minified, uglified, with Spring Boot backend).
- - **ModellingPlatform-Dev:** Development project for the Angular 1 modelling platform frontend (with node server backend).
- - **ModellingPlatform:** Production project for the Angular 1 modelling platform frontend (with Spring Boot backend).
-
-> A new version of the S-BPM modelling platform is available [here](https://github.com/mkolodiy/s-bpm-modeler).
-
-## Tutorial Videos ##
-[ModellingPlatform](https://youtu.be/3gJXmBRKWNo)
-
-[ExecutionPlatform](https://youtu.be/LkoJVZ__f1k)
-
-## Functionalities ##
-
-
-### Execution ###
-| Functionality | Implemented | Comment |
-| ------------ | ------------ | ------- |
-| Internal Subjects | Yes | - |
-| Multisubjects | No | - |
-| External Subjects | Yes | partially (Engine) |
-| Function States | Yes | - |
-| Send States | Yes | - |
-| Receive States | Yes | - |
-| Timeouts | Yes | partially (Engine) |
-| Refinements | Yes | partially (Engine) |
-| Business Objects | Yes | - |
-| Start Process | Yes | - |
-| Stop Process | Yes | - |
-| Nested Business Objects | Yes | partially (Engine) || Formbuilder | Yes | - |
-| OWL-Import | Yes | standard-pass-ont v0.7.2. & v0.7.5. |
-| Connected Processes | Yes | partially (Engine) |
-| Multiprocesses | Yes | partially (Engine) |
-| Event logging | Yes | Json and CSV |
-
-### Modelling ###
-| Functionality | Implemented | Comment |
-| ------------ | ------------ | ------- |
-|SID View|yes|-|
-|SBD View|yes|-|
-|Subjects|yes|-|
-|Message Connector|yes|-|
-|Message Types (Business Objects)|yes|-|
-|Send State|yes|-|
-|Receive State|yes|-|
-|Function State|yes|-|
-|OWL-Import|no|standard-pass-ont|
-|OWL-Export|yes|-|
-|ZoomIn/Out|no|-|
-|Customizability|no|-|
-
-## Master theses ##
-In this section you will find Master's theses, which provide further information about the project.
-
- - Development of a Microservice-based Architecture for Storing and Executing Subject-oriented Processes (german) by Stefan Stani [Link](master_theses/MA-Stani-Stefan.pdf) 
-
-## Setup ##
-### Prerequisites ###
-
- - Java Platform (JDK) 8
- - MySQL
- 
-**Development only:**
- - NodeJS for Angular development in GUI-Dev and ModellingPlatform-Dev
- - Gulp for Angular development in ModellingPlatform-Dev
-
-### Database Settings ###
-Please execute following statements to create the schema and the db user in your MySQL database:
-[DB_setup.sql](Setup/DB_setup.sql)
-
-## Startup ##
-### Start everything (Windows) ###
- 1. Start the MySQL Service
- 2. Go to [Setup/start_windows](Setup/start_windows)
- 3. Open [start.bat](Setup/start_windows/start.bat)
-
-### Execution Platform ###
- 1. Start the MySQL Service
- 2. Go to ServiceDiscovery and run in cmd:
- ```gradlew bootRun```
- 3. Go to ConfigurationService and run in cmd:
- ```gradlew bootRun```
- 4. Go to ProcessModelStorage and run in cmd: 
- ```gradlew bootRun```
- 5. Go to ProcessEngine and run in cmd: 
- ```gradlew bootRun```
- 6. Go to Gateway and run in cmd: 
- ```gradlew bootRun```
- 7. Go to ExternalCommunicator and run in cmd: 
- ```gradlew bootRun```
- 8. Go to EventLogger and run in cmd: 
- ```gradlew bootRun```
- 9. Go to GUI and run in cmd: 
- ```gradlew bootRun```
- 10. Go to ```http://localhost:3000```
- 
-### Modelling Platform ###
- 1. Go to ModellingPlatform and run in cmd: 
- ```gradlew bootRun```
- 2. Go to ```http://localhost:4000```
- 
-#### Alternative ####
-If you prefer to run the jar files, without using gradlew:
- 1. Go to [builds](builds)
- 2. run in cmd: ```java -jar ModellingPlatform-0.0.1-SNAPSHOT.jar```
- 3. Go to ```http://localhost:4000```
- 
-
-
-### GUI-Dev ###
-Just for development purposes, not for production!
- 1. run in cmd: ```npm install```
- 2. Go to GUI-Dev and run in cmd: ```npm start```
- 3. in case of any errors when starting the first time, please stick to the installation guide of [ng2-admin](https://github.com/akveo/ng2-admin/)
- 4. Go to ```http://localhost:3000```
-
-### ModellingPlatform-Dev ###
-Just for development purposes, not for production!
- 1. Run ```npm install -g yo bower grunt-cli gulp && npm install && bower install``` to install required dependencies.
- 2. Go to ModellingPlatform-Dev and run in cmd: ```npm install && bower install```
- 3. Run in cmd: ```gulp serve```
- 4. Go to ```http://localhost:3000```
- 
-## Configuration ##
-
-### Ports ###
-Basically, the following ports are used:
-
-|  Service  |  Port  |
-|  -------  |  ----- |
-|  Gateway  |  10000 |
-|  ServiceDiscovery  |  8761 |
-|  ConfigurationService  |  8888 |
-|  ProcessModelStorage  |  Random  |
-|  ProcessEngine  |  Random  |
-|  ExternalCommunicator | Random |
-|  EventLogger  | Random |
-|  GUI  |  3000  |
-|  ModellingPlatform  |  4000  |
-
-To change the port configuration, change the server port in this file e.g. Gateway: [application.properties] (Gateway/src/main/resources/application.properties)
-
-**Note:** If you change the port of the Gateway, make sure to change the restApi configuration in [processes.service.ts](GUI-Dev/src/app/processes.service.ts) and to rebuild the GUI-Dev and GUI project according to the guide provide [below](#gui).
-
-### User Configuration ###
-In general, the authentication concept ist based on RBAC. Each user can be assigned to one or more roles. Each role can be assigned to one more rules.
-
-The current *.csv files for the user configuration:
-- [users.csv](Gateway/src/main/resources/memoryusers/users.csv)
-- [roles.csv](Gateway/src/main/resources/memoryusers/roles.csv)
-- [rules.csv](Gateway/src/main/resources/memoryusers/rules.csv)
-
-##### Standard configuration: #####
-
-|  User  |  Roles  |  Password  |
-|  ----  |  -----  |  --------  |
-|  robert  |  BOSS  |  1234  |
-|  matthias  |  ADMIN, EMPLOYEE  |  1234  |
-|  stefan  |  EMPLOYEE  |  1234  |
-|  maksym  |  EMPLOYEE  |  1234  |
-|  marlene |  TRAVEL MANAGEMENT | 1234 |
-
-## Development ##
-### Spring Boot Modules ###
-Any further development concerning the ServiceDiscovery, the ConfigurationService, the Gateway, the ProcessModelStorage, the ExternalCommunicator or the ProcessEngine can be done directly in java. For further information please use the [Spring Boot Documentation](https://projects.spring.io/spring-boot/)
-
-**Note:** If you do any changes to a module, you have to rebuild it with ```gradlew build```
-
-### GUI ###
-Any further development concerning the GUI has to be done in the GUI-Dev module by using typescript and Angular 2. For further information please use the [Angular Documentation](https://angular.io/) and the [ng2-admin Documentation](https://akveo.github.io/ng2-admin/articles/001-getting-started/).
-
-**Note:** If you do any changes to the GUI-Dev project, you have to update the GUI project afterwards:
- 1. Go to GUI-Dev and run in cmd: ```npm run prebuild:prod && npm run build:prod```
- 2. Go to [GUI/src/main/resources/public/](GUI/src/main/resources/public/) and remove of all of its content.
- 3. Go to [GUI-Dev/dist](GUI-Dev/dist) and move all of its content to [GUI/src/main/resources/public/](GUI/src/main/resources/public/).
- 4. Go to [GUI](GUI) and run ```gradlew build``` or ```gradlew run```
- 
-### ModellingPlatform ###
-Any further development concerning the ModellingPlatform has to be done in the ModellingPlatform-Dev module by using javascript and Angular 1.
-
-**Note:** If you do any changes to the ModellingPlatform-Dev project, you have to update the ModellingPlatform project afterwards:
- 1. Go to ModellingPlatform-Dev and run in cmd: ```gulp build```
- 2. Go to [ModellingPlatform/src/main/resources/public/](ModellingPlatform/src/main/resources/public/) and remove of all of its content.
- 3. Go to [ModellingPlatform-Dev/dist](ModellingPlatform-Dev/dist) and move all of its content to [ModellingPlatform/src/main/resources/public/](ModellingPlatform/src/main/resources/public/).
- 4. Go to [ModellingPlatform](ModellingPlatform) and run ```gradlew build``` or ```gradlew run```
- 
-**Note:** You can change the appearance of the elements by modify the following file: [ui-joint-shape.template.scss](ModellingPlatform-dev/src/app/components/services/ui-joint/ui-joint-shape/ui-joint-shape.template.scss)
- 
-## License ##
+# S-BPM Modelling and Execution Platform
+  
+This is a modelling and execution platform for S-BPM processes, based on microservices powered by Spring Boot. The modelling platform is based on Angular 1, the frontend for the execution platform, however, is based on Angular 2.  
+Basically, the platform consists of the following modules:  
+ - **ServiceDiscovery:** Automatic detection of devices and services.  
+ - **ConfigurationService:** Central repository for configuration files.  
+ - **ProcessModelStorage:** This is the process repository.  
+ - **ProcessEngine:** Responsible for the execution of processes, based on Akka.  
+ - **EventLogger:** Logs events during execution, exports logs in CSV format, manipulates PNML files and transforms manipulated PNML files to OWL files.  
+ - **Gateway:** Authentication and authorization service and handles the requests of the process execution frontend (GUI).  
+ - **Persistence:** Hibernate mapping of the database tables.  
+ - **ExternalCommunicator:** For the support of external projects.  
+ - **GUI-Dev:** Development project for the Angular 2 execution platform frontend (With some dev tools, with node server backend).  
+ - **GUI:** Production project for the Angular 2 execution platform frontend (minified, uglified, with Spring Boot backend).  
+ - **ModellingPlatform-Dev:** Development project for the Angular 1 modelling platform frontend (with node server backend).  
+ - **ModellingPlatform:** Production project for the Angular 1 modelling platform frontend (with Spring Boot backend).  
+  
+> A new version of the S-BPM modelling platform is available [here](https://github.com/mkolodiy/s-bpm-modeler).  
+  
+## Tutorial Videos
+[ModellingPlatform](https://youtu.be/3gJXmBRKWNo)  
+  
+[ExecutionPlatform](https://youtu.be/LkoJVZ__f1k)  
+  
+## Functionalities
+  
+  
+### Execution
+| Functionality | Implemented | Comment |  
+| ------------ | ------------ | ------- |  
+| Internal Subjects | Yes | - |  
+| Multisubjects | No | - |  
+| External Subjects | Yes | partially (Engine) |  
+| Function States | Yes | - |  
+| Send States | Yes | - |  
+| Receive States | Yes | - |  
+| Timeouts | Yes | partially (Engine) |  
+| Refinements | Yes | partially (Engine) |  
+| Business Objects | Yes | - |  
+| Start Process | Yes | - |  
+| Stop Process | Yes | - |  
+| Nested Business Objects | Yes | partially (Engine) || Formbuilder | Yes | - |  
+| OWL-Import | Yes | standard-pass-ont v0.7.2. & v0.7.5. |  
+| Connected Processes | Yes | partially (Engine) |  
+| Multiprocesses | Yes | partially (Engine) |  
+| Event logging | Yes | Json and CSV |  
+  
+### Modelling 
+| Functionality | Implemented | Comment |  
+| ------------ | ------------ | ------- |  
+|SID View|yes|-|  
+|SBD View|yes|-|  
+|Subjects|yes|-|  
+|Message Connector|yes|-|  
+|Message Types (Business Objects)|yes|-|  
+|Send State|yes|-|  
+|Receive State|yes|-|  
+|Function State|yes|-|  
+|OWL-Import|no|standard-pass-ont|  
+|OWL-Export|yes|-|  
+|ZoomIn/Out|no|-|  
+|Customizability|no|-|  
+  
+## Master theses
+In this section you will find Master's theses, which provide further information about the project.  
+  
+ - Development of a Microservice-based Architecture for Storing and Executing Subject-oriented Processes (german) by Stefan Stani [Link](master_theses/MA-Stani-Stefan.pdf)   
+  
+## Setup
+### Prerequisites
+  
+ - Java Platform (JDK) 8  
+ - MySQL  or [Docker](https://www.docker.com/get-docker) (Docker is recommended)
+   
+**Development only:**  
+ - NodeJS for Angular development in GUI-Dev and ModellingPlatform-Dev  
+ - Gulp for Angular development in ModellingPlatform-Dev  
+  
+### Database Settings
+#### For non-docker users:
+- Install  the mysql database on your machine and start the service.
+- Execute following statements to create the schema and the db user in your MySQL database:  [DB_setup.sql](Setup/mysql_docker/DB_setup.sql)
+#### For docker users:
+- `cd` into the `/Setup/mysql_docker` folder of the project
+- Make sure that docker is already installed on your machine
+- Execute the following command in the `/Setup/mysql_docker` directory: `docker-compose up`
+	- The command will build a new mysql docker image and start a container which is preconfigured. No further configuration is needed as the database is set-up automatically.
+	- **_Tipp:_** To truncate the output of docker in the terminal, use the following command: `docker-compose up -d`
+  
+## Startup
+### Start the MySQL database
+#### Non-docker:
+ 1. Ensure that the service is started and up and running. Otherwise start the database service.
+#### Docker:
+ 1. Check if the newly created docker container named `ebusa-mysql` is up and running by using the command `docker ps`.
+ 2. If the docker container is not running, start it by using the command `docker start ebusa-mysql`.
+### Start all services on _Windows_  
+ 1. Go to [Setup/start_windows](Setup/start_windows)  
+ 2. Execute [start.bat](Setup/start_windows/start.bat) 
+    2.1 To enable the [example processes](#enabling-the-example-processes:), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`.
+### Start all services on _Linux/macOS_
+1. Go to [Setup/start_unix](Setup/start_unix)
+2. Execute the bash script `start.sh`.
+	2.1 The script will automatically detect if your machine is running _Linux_ or _macOS_.
+	2.2 If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with 			the following command: `chmod +x start.sh`.
+	2.3 To enable the [example processes](#enabling-the-example-processes:), execute the script with the following argument: `./start.sh -dev=true`.
+### Execution Platform
+ 1. Start the MySQL Service  
+ 2. Go to ServiceDiscovery and run in cmd:  
+ ```gradlew bootRun```  
+ 3. Go to ConfigurationService and run in cmd:  
+ ```gradlew bootRun```  
+ 4. Go to ProcessModelStorage and run in cmd:   
+ ```gradlew bootRun```  
+ 5. Go to ProcessEngine and run in cmd:   
+ ```gradlew bootRun```  
+ 6. Go to Gateway and run in cmd:   
+ ```gradlew bootRun```  
+ 7. Go to ExternalCommunicator and run in cmd:   
+ ```gradlew bootRun```  
+ 8. Go to EventLogger and run in cmd:   
+ ```gradlew bootRun```  
+ 9. Go to GUI and run in cmd:   
+ ```gradlew bootRun```  
+ 10. Go to ```http://localhost:3000```  
+  ### Modelling Platform ###  
+ 1. Go to ModellingPlatform and run in cmd:   
+ ```gradlew bootRun```  
+ 2. Go to ```http://localhost:4000```  
+  #### Alternative ####  
+If you prefer to run the jar files, without using gradlew:  
+ 1. Go to [builds](builds)  
+ 2. run in cmd: ```java -jar ModellingPlatform-0.0.1-SNAPSHOT.jar```  
+ 3. Go to ```http://localhost:4000```  
+    
+  
+### GUI-Dev
+Just for development purposes, not for production!  
+ 1. run in cmd: ```npm install```  
+ 2. Go to GUI-Dev and run in cmd: ```npm start```  
+ 3. in case of any errors when starting the first time, please stick to the installation guide of [ng2-admin](https://github.com/akveo/ng2-admin/)  
+ 4. Go to ```http://localhost:3000```  
+  
+### ModellingPlatform-Dev
+Just for development purposes, not for production!  
+ 1. Run ```npm install -g yo bower grunt-cli gulp && npm install && bower install``` to install required dependencies.  
+ 2. Go to ModellingPlatform-Dev and run in cmd: ```npm install && bower install```  
+ 3. Run in cmd: ```gulp serve```  
+ 4. Go to ```http://localhost:3000```  
+  ## Configuration ##  
+  
+### Ports
+Basically, the following ports are used:  
+  
+|  Service  |  Port  |  
+|  -------  |  ----- |  
+|  Gateway  |  10000 |  
+|  ServiceDiscovery  |  8761 |  
+|  ConfigurationService  |  8888 |  
+|  ProcessModelStorage  |  Random  |  
+|  ProcessEngine  |  Random  |  
+|  ExternalCommunicator | Random |  
+|  EventLogger  | Random |  
+|  GUI  |  3000  |  
+|  ModellingPlatform  |  4000  |  
+  
+To change the port configuration, change the server port in this file e.g. Gateway: [application.properties] (Gateway/src/main/resources/application.properties)  
+  
+**Note:** If you change the port of the Gateway, make sure to change the restApi configuration in [processes.service.ts](GUI-Dev/src/app/processes.service.ts) and to rebuild the GUI-Dev and GUI project according to the guide provide [below](#gui).  
+  
+### User Configuration
+In general, the authentication concept ist based on RBAC. Each user can be assigned to one or more roles. Each role can be assigned to one more rules.  
+  
+The current *.csv files for the user configuration:  
+- [users.csv](Gateway/src/main/resources/memoryusers/users.csv)  
+- [roles.csv](Gateway/src/main/resources/memoryusers/roles.csv)  
+- [rules.csv](Gateway/src/main/resources/memoryusers/rules.csv)  
+  
+##### Standard configuration: #####  
+  
+|  User  |  Roles  |  Password  |  
+|  ----  |  -----  |  --------  |  
+|  robert  |  BOSS  |  1234  |  
+|  matthias  |  ADMIN, EMPLOYEE  |  1234  |  
+|  stefan  |  EMPLOYEE  |  1234  |  
+|  maksym  |  EMPLOYEE  |  1234  |  
+|  marlene |  TRAVEL MANAGEMENT | 1234 |  
+  
+## Development
+### Enable/Disable Example Processes
+For the development process it is possible to activate the creation of example processes in order to avoid the manual creation of them during development and testing. The required steps are explained on page 72 in the [master theses](master_theses/MA-Stani-Stefan.pdf). 
+The following steps are describing the steps mentioned in the thesis:
+#### Enabling the Example Processes:
+- Change the parameter `ippr.insert-examples.enabled` to `true` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
+- Change the parameter `spring.jpa.hibernate.ddl-auto` to `create` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
+- **Disable** the execution of the `ConfigurationService` microservice to avoid overwriting the configuration file. (See _start all services for_ [Windows](#start-all-services-on-_windows_) or [Linux/macOS](#start-all-services-on-_linux/macos_) how to do it)
+#### Disable the Example Processes:
+- Change the parameter `ippr.insert-examples.enabled` to `false` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
+- Change the parameter `spring.jpa.hibernate.ddl-auto` to `update` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
+- **Enable** the execution of the `ConfigurationService` microservice. (See _start all services for_ [Windows](#start-all-services-on-_windows_) or [Linux/macOS](#start-all-services-on-_linux/macos_) how to do it)
+### Spring Boot Modules
+Any further development concerning the ServiceDiscovery, the ConfigurationService, the Gateway, the ProcessModelStorage, the ExternalCommunicator or the ProcessEngine can be done directly in java. For further information please use the [Spring Boot Documentation](https://projects.spring.io/spring-boot/)  
+  
+**Note:** If you do any changes to a module, you have to rebuild it with ```gradlew build```  
+  
+### GUI
+Any further development concerning the GUI has to be done in the GUI-Dev module by using typescript and Angular 2. For further information please use the [Angular Documentation](https://angular.io/) and the [ng2-admin Documentation](https://akveo.github.io/ng2-admin/articles/001-getting-started/).  
+  
+**Note:** If you do any changes to the GUI-Dev project, you have to update the GUI project afterwards:  
+ 1. Go to GUI-Dev and run in cmd: ```npm run prebuild:prod && npm run build:prod```  
+ 2. Go to [GUI/src/main/resources/public/](GUI/src/main/resources/public/) and remove of all of its content.  
+ 3. Go to [GUI-Dev/dist](GUI-Dev/dist) and move all of its content to [GUI/src/main/resources/public/](GUI/src/main/resources/public/).  
+ 4. Go to [GUI](GUI) and run ```gradlew build``` or ```gradlew run```  
+  ### ModellingPlatform ###  
+Any further development concerning the ModellingPlatform has to be done in the ModellingPlatform-Dev module by using javascript and Angular 1.  
+  
+**Note:** If you do any changes to the ModellingPlatform-Dev project, you have to update the ModellingPlatform project afterwards:  
+ 1. Go to ModellingPlatform-Dev and run in cmd: ```gulp build```  
+ 2. Go to [ModellingPlatform/src/main/resources/public/](ModellingPlatform/src/main/resources/public/) and remove of all of its content.  
+ 3. Go to [ModellingPlatform-Dev/dist](ModellingPlatform-Dev/dist) and move all of its content to [ModellingPlatform/src/main/resources/public/](ModellingPlatform/src/main/resources/public/).  
+ 4. Go to [ModellingPlatform](ModellingPlatform) and run ```gradlew build``` or ```gradlew run```  
+  **Note:** You can change the appearance of the elements by modify the following file: [ui-joint-shape.template.scss](ModellingPlatform-dev/src/app/components/services/ui-joint/ui-joint-shape/ui-joint-shape.template.scss)  
+   
+## License
 [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -93,18 +93,18 @@ In this section you will find Master's theses, which provide further information
 #### Non-docker:
  1. Ensure that the service is started and up and running. Otherwise start the database service.
 #### Docker:
- 1. Check if the newly created docker container named `ebusa-mysql` is up and running by using the command `docker ps`.
+ 1. Check if the newly created docker container named `ebusa-mysql` is running by using the command `docker ps`.
  2. If the docker container is not running, start it by using the command `docker start ebusa-mysql`.
 ### Start all services on _Windows_  
  1. Go to [Setup/start_windows](Setup/start_windows)  
  2. Execute [start.bat](Setup/start_windows/start.bat) 
-    2.1 To enable the [example processes](#enabling-the-example-processes:), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`.
+    - To enable the [example processes](#enabledisable-example-processes), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`.
 ### Start all services on _Linux/macOS_
 1. Go to [Setup/start_unix](Setup/start_unix)
 2. Execute the bash script `start.sh`.
-	2.1 The script will automatically detect if your machine is running _Linux_ or _macOS_.
-	2.2 If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with 			the following command: `chmod +x start.sh`.
-	2.3 To enable the [example processes](#enabling-the-example-processes:), execute the script with the following argument: `./start.sh -dev=true`.
+	- The script will automatically detect if your machine is running _Linux_ or _macOS_.
+	- If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with 			the following command: `chmod +x start.sh`.
+	- To enable the [example processes](#enabledisable-example-processes), execute the script with the following argument: `./start.sh -dev=true`.
 ### Execution Platform
  1. Start the MySQL Service  
  2. Go to ServiceDiscovery and run in cmd:  
@@ -194,11 +194,11 @@ The following steps are describing the steps mentioned in the thesis:
 #### Enabling the Example Processes:
 - Change the parameter `ippr.insert-examples.enabled` to `true` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
 - Change the parameter `spring.jpa.hibernate.ddl-auto` to `create` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
-- **Disable** the execution of the `ConfigurationService` microservice to avoid overwriting the configuration file. (See _start all services for_ [Windows](#start-all-services-on-_windows_) or [Linux/macOS](#start-all-services-on-_linux/macos_) how to do it)
+- **Disable** the execution of the `ConfigurationService` microservice to avoid overwriting the configuration file. (See _start all services for_ [Windows](#start-all-services-on-windows) or [Linux/macOS](#start-all-services-on-linuxmacos) how to do it)
 #### Disable the Example Processes:
 - Change the parameter `ippr.insert-examples.enabled` to `false` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
 - Change the parameter `spring.jpa.hibernate.ddl-auto` to `update` in the `application.properties` file found in the directory `/ProcessModelStorage/src/main/resources`
-- **Enable** the execution of the `ConfigurationService` microservice. (See _start all services for_ [Windows](#start-all-services-on-_windows_) or [Linux/macOS](#start-all-services-on-_linux/macos_) how to do it)
+- **Enable** the execution of the `ConfigurationService` microservice. (See _start all services for_ [Windows](#start-all-services-on-windows) or [Linux/macOS](#start-all-services-on-linuxmacos) how to do it)
 ### Spring Boot Modules
 Any further development concerning the ServiceDiscovery, the ConfigurationService, the Gateway, the ProcessModelStorage, the ExternalCommunicator or the ProcessEngine can be done directly in java. For further information please use the [Spring Boot Documentation](https://projects.spring.io/spring-boot/)  
   

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ In this section you will find Master's theses, which provide further information
  2. If the docker container is not running, start it by using the command `docker start ebusa-mysql`.
 ### Start all services on _Windows_  
  1. Go to [Setup/start_windows](Setup/start_windows)  
- 2. Execute [start.bat](Setup/start_windows/start.bat) 
-    - To enable the [example processes](#enabledisable-example-processes), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`. 
+ 2. Execute [start.bat](Setup/start_windows/start.bat)
+    - Do **not** execute the `start.bat` script with administrator privileges, as it will not be able to execute all services.
+    - To enable the [example processes](#enabledisable-example-processes), execute the `start.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`. 
     Also check the section for further configuration details.
 ### Start all services on _Linux/macOS_
 1. Go to [Setup/start_unix](Setup/start_unix)

--- a/README.md
+++ b/README.md
@@ -98,13 +98,15 @@ In this section you will find Master's theses, which provide further information
 ### Start all services on _Windows_  
  1. Go to [Setup/start_windows](Setup/start_windows)  
  2. Execute [start.bat](Setup/start_windows/start.bat) 
-    - To enable the [example processes](#enabledisable-example-processes), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`.
+    - To enable the [example processes](#enabledisable-example-processes), start the `.bat` script and choose `dev mode`. Otherwise you can use the `normal mode`. 
+    Also check the section for further configuration details.
 ### Start all services on _Linux/macOS_
 1. Go to [Setup/start_unix](Setup/start_unix)
 2. Execute the bash script `start.sh`.
 	- The script will automatically detect if your machine is running _Linux_ or _macOS_.
 	- If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with 			the following command: `chmod +x start.sh`.
 	- To enable the [example processes](#enabledisable-example-processes), execute the script with the following argument: `./start.sh -dev=true`.
+	 Also check the section for further configuration details.
 ### Execution Platform
  1. Start the MySQL Service  
  2. Go to ServiceDiscovery and run in cmd:  

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# S-BPM Modelling and Execution Platform
+# S-BPM (Modelling), Execution and Store Platform
   
-This is a modelling and execution platform for S-BPM processes, based on microservices powered by Spring Boot. The modelling platform is based on Angular 1, the frontend for the execution platform, however, is based on Angular 2.  
+This is a (modelling), execution and store platform for S-BPM processes, based on microservices powered by Spring Boot. The modelling platform is based on Angular 1, the frontend for the execution and store platform, however, is based on Angular 2+.  
 Basically, the platform consists of the following modules:  
  - **ServiceDiscovery:** Automatic detection of devices and services.  
  - **ConfigurationService:** Central repository for configuration files.  
@@ -14,9 +14,15 @@ Basically, the platform consists of the following modules:
  - **GUI-Dev:** Development project for the Angular 2 execution platform frontend (With some dev tools, with node server backend).  
  - **GUI:** Production project for the Angular 2 execution platform frontend (minified, uglified, with Spring Boot backend).  
  - **ModellingPlatform-Dev:** Development project for the Angular 1 modelling platform frontend (with node server backend).  
- - **ModellingPlatform:** Production project for the Angular 1 modelling platform frontend (with Spring Boot backend).  
+ - **ModellingPlatform:** Production project for the Angular 1 modelling platform frontend (with Spring Boot backend).
+ > A new version of the S-BPM modelling platform is available [here](https://github.com/mkolodiy/s-bpm-modeler).
+
+## Further Development - EBUSA AIM17
+The project hosted in this repository is a fork of the original project, where the intention was to build a S-BPM Modelling and Execution Platform.
+This fork however, aims to extend the platform by adding process-store functionality. This should allow for searching, buying, 
+selling, reviewing and executing processes from the store(=market). Furthermore, organizations should be allowed to register and
+invite employees (as users) to the platform, and to give them different roles and rules.
   
-> A new version of the S-BPM modelling platform is available [here](https://github.com/mkolodiy/s-bpm-modeler).  
   
 ## Tutorial Videos
 [ModellingPlatform](https://youtu.be/3gJXmBRKWNo)  
@@ -108,7 +114,7 @@ In this section you will find Master's theses, which provide further information
 	- To enable the [example processes](#enabledisable-example-processes), execute the script with the following argument: `./start.sh -dev=true`.
 	 Also check the section for further configuration details.
 ### Execution Platform
- 1. Start the MySQL Service  
+ 1. Start the MySQL Service or Docker Container
  2. Go to ServiceDiscovery and run in cmd:  
  ```gradlew bootRun```  
  3. Go to ConfigurationService and run in cmd:  
@@ -167,7 +173,7 @@ Basically, the following ports are used:
 |  GUI  |  3000  |  
 |  ModellingPlatform  |  4000  |  
   
-To change the port configuration, change the server port in this file e.g. Gateway: [application.properties] (Gateway/src/main/resources/application.properties)  
+To change the port configuration, change the server port in this file e.g. Gateway: [application.properties](Gateway/src/main/resources/application.properties)  
   
 **Note:** If you change the port of the Gateway, make sure to change the restApi configuration in [processes.service.ts](GUI-Dev/src/app/processes.service.ts) and to rebuild the GUI-Dev and GUI project according to the guide provide [below](#gui).  
   

--- a/Setup/start_unix/start.sh
+++ b/Setup/start_unix/start.sh
@@ -4,6 +4,7 @@ echo ======================================
 echo checking OS ...
 
 OS='unknown'
+devMode='false'
 UNAMESTR=$(uname)
 
 if [[ "$UNAMESTR" == 'Linux' ]]; then
@@ -11,10 +12,24 @@ if [[ "$UNAMESTR" == 'Linux' ]]; then
     echo Linux detected ...
 elif [[ "$UNAMESTR" == 'Darwin' ]]; then
     OS='macOS'
-    echo Mac detected ...
+    echo macOS detected ...
 else
     echo No supported UNIX system detected
 fi
+
+if [[ "$1" == '-dev=true' ]]; then
+    devMode='true'
+    echo Development mode activated.
+    echo The execution of the ConfigurationService will be omitted.
+elif [[ "$1" == '-dev=false' ]]; then
+    devMode='false'
+    echo Normal mode activated.
+    echo All services will be executed normally.
+else
+    echo No \(recognized\) mode was passed as an argument.
+    echo All services will be executed normally.
+fi
+
 echo ======================================
 
 # start on Linux // tested with Ubuntu 17.10 running X11/Gnome
@@ -24,8 +39,10 @@ if [[ "$OS" == 'linux' ]]; then
     echo ======================================
     echo - ServiceDiscovery
     x-terminal-emulator -e bash start_service_discovery.sh
+    if [[ "$devMode" == 'false' ]]; then
     echo - ConfigurationService
-    #x-terminal-emulator -e bash start_configuration_service.sh
+    x-terminal-emulator -e bash start_configuration_service.sh
+    fi
     echo - ProcessModelStorage
     x-terminal-emulator -e bash start_pms.sh
     echo - ProcessEngine
@@ -47,45 +64,53 @@ if [[ "$OS" == 'linux' ]]; then
 
 # start on macOS // tested with macOS Sierra (10.12.6)
 elif [[ "$OS" == 'macOS' ]]; then
+    info_log_cfg_service="Tab3 - ConfigurationService"
+    injectScript_new_tab="tell application \"System Events\" to keystroke \"t\" using {command down}"
+    injectScript_delay="\"delay 0.07\""
+    injectScript_start_config_service="tell application \"Terminal\" to do script \"./start_configuration_service.sh\" in selected tab of the front window"
+    if [[ "$devMode" == 'true' ]]; then
+        info_log_cfg_service="Tab3 - ConfigurationService (disabled in dev mode)"
+        injectScript_start_config_service="tell application \"Terminal\" to do script \"ConfigurationService was not executed because the dev mode was selected!\" in selected tab of front window"
+    fi
     echo Running AppleScript.
     echo New Terminal window will open to run scripts.
     echo ======================================
-    echo Tab2 - ServiceDiscovery && echo Tab3 - ConfigurationService && echo Tab4 - ProcessModelStorage \
+    echo Tab2 - ServiceDiscovery && echo ${info_log_cfg_service} && echo Tab4 - ProcessModelStorage \
     && echo Tab5 - ProcessEngine && echo Tab6 - Gateway && echo Tab7 - ExternalCommunicator && echo Tab8 - EventLogger \
     && echo Tab9 - GUI && echo Tab10 - Modelling Platform
     echo ======================================
     osascript \
         -e "tell application \"Terminal\" to activate" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"cd $(PWD)\" in selected tab of the front window" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"chmod +x *.sh\" in selected tab of the front window" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_service_discovery.sh\" in selected tab of the front window" \
-        #-e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        #-e "delay 0.05" \
-        #-e "tell application \"Terminal\" to do script \"./start_configuration_service.sh\" in selected tab of the front window" \
+        -e "${injectScript_new_tab}" \
+        -e "${injectScript_delay}" \
+        -e "${injectScript_start_config_service}" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_pms.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_engine.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_gateway.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_ec.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_event_logger.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_gui.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.05" \
+        -e "delay 0.07" \
         -e "tell application \"Terminal\" to do script \"./start_mpf.sh\" in selected tab of the front window"
     echo All services have been executed!
     echo Check Terminal window and tabs for different services.

--- a/Setup/start_windows/start.bat
+++ b/Setup/start_windows/start.bat
@@ -1,12 +1,31 @@
 @echo off
 
+echo You can start the services by choosing between dev mode and normal mode.
+echo Dev-mode: Will skip the execution of the ConfigurationService
+echo Normal-mode: Will start all services normally.
+echo ########################################################## & echo.
+:MODECHOICE
+echo Choose between normal mode (1) or dev mode (2):
+echo 1 - Normal mode
+echo 2 - Dev mode
+
+set /p mode=
+
 echo Start IPPR2016
 echo ########################################################## & echo.
 
-REM echo Start ConfigurationService
-REM echo ########################################################## & echo.
-REM start start_configuration_service.bat
-REM echo. & echo ##########################################################
+if %mode%==1 (
+echo Start ConfigurationService
+echo ########################################################## & echo.
+start start_configuration_service.bat
+echo. & echo ##########################################################
+) else if %mode%==2 (
+echo Skipping Start ConfigurationService because dev mode is selected
+echo ########################################################## & echo.
+) else (
+echo Bad Input. Input should either be '1' or '2'.
+GOTO MODECHOICE
+)
 
 echo Start ServiceDiscovery
 echo ########################################################## & echo.


### PR DESCRIPTION
resolves #2 

**DONE:**

- Updated `README.md`.
  - General info added for repo and the intention of the fork
  - Added instructions on how to set-up docker container for mysql
  - Added instructions on how to execute all services by using either the `start.bat` or `start.sh` scripts
  - Explained how to enable/disable the example processes which were discussed in the PR #54.
  - Added further description and instructions on how to completely enable/disable the example processes.
- Adapted the `start.sh` and `start.bat` scripts:
  - Both scripts now support dev mode or normal mode. This allows for skipping the execution of the `ConfigurationService` to use the example processes.

**ToDo:**
- @loete Please test the `start.sh` script on Linux with dev mode and without dev mode
  - Disabling dev mode (i.e. running the normal mode) does not require any arguments.
- @tortmann Please test the `start.bat` script on Windows with dev mode and without dev mode (normal mode) 

> Read README in the associated branch for further information.