### PR TITLE
Update start.sh and add info for zsh users

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ In this section you will find Master's theses, which provide further information
 ### Start all services on _Linux/macOS_
 1. Go to [Setup/start_unix](Setup/start_unix)
 2. Execute the bash script `start.sh`.
+    - **NOTE:** It is strongly recommended to use `/bin/bash` and **NOT** to use a `zsh` shell as this can cause issues.
+        - To change your default shell, you can use the command `chsh -s /bin/bash`. To change it back to your custom shell, use the same command (i.e. `chsh -s /bin/zsh`)
 	- The script will automatically detect if your machine is running _Linux_ or _macOS_.
-	- If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with 			the following command: `chmod +x start.sh`.
-	- To enable the [example processes](#enabledisable-example-processes), execute the script with the following argument: `./start.sh -dev=true`.
+	- If the script cannot be executed due to permission rights, set the execution permission for the `start.sh` script with the following command: `chmod +x start.sh`.
+	- To enable the [example processes](#enabledisable-example-processes), execute the script with the following argument: `./start.sh -dev`.
 	 Also check the section for further configuration details.
 ### Execution Platform
  1. Start the MySQL Service or Docker Container

--- a/Setup/start_unix/start.sh
+++ b/Setup/start_unix/start.sh
@@ -17,11 +17,11 @@ else
     echo No supported UNIX system detected
 fi
 
-if [[ "$1" == '-dev=true' ]]; then
+if [[ "$@" == '-dev' ]]; then
     devMode='true'
     echo Development mode activated.
     echo The execution of the ConfigurationService will be omitted.
-elif [[ "$1" == '-dev=false' ]]; then
+elif [[ "$@" == '-dev' ]]; then
     devMode='false'
     echo Normal mode activated.
     echo All services will be executed normally.
@@ -62,15 +62,16 @@ if [[ "$OS" == 'linux' ]]; then
 
 
 
-# start on macOS // tested with macOS Sierra (10.12.6)
+# start on macOS // tested with macOS Sierra (10.12.6) & macOS High Sierra (10.13.3)
+# tested with normal bash and zsh
 elif [[ "$OS" == 'macOS' ]]; then
     info_log_cfg_service="Tab3 - ConfigurationService"
-    injectScript_new_tab="tell application \"System Events\" to keystroke \"t\" using {command down}"
-    injectScript_delay="\"delay 0.07\""
-    injectScript_start_config_service="tell application \"Terminal\" to do script \"./start_configuration_service.sh\" in selected tab of the front window"
+    injectCmd_new_tab="tell application \"System Events\" to keystroke \"t\" using {command down}"
+    injectCmd_delay="delay 0.12"
+    injectCmd_start_config_service="tell application \"Terminal\" to do script \"./start_configuration_service.sh\" in selected tab of the front window"
     if [[ "$devMode" == 'true' ]]; then
-        info_log_cfg_service="Tab3 - ConfigurationService (disabled in dev mode)"
-        injectScript_start_config_service="tell application \"Terminal\" to do script \"ConfigurationService was not executed because the dev mode was selected!\" in selected tab of front window"
+        info_log_cfg_service="Tab3 - EMPTY (ConfigurationService disabled in dev mode)"
+        injectCmd_start_config_service="tell application \"Terminal\" to do script \"ConfigurationService was not executed because the dev mode was selected!\" in selected tab of front window"
     fi
     echo Running AppleScript.
     echo New Terminal window will open to run scripts.
@@ -81,36 +82,38 @@ elif [[ "$OS" == 'macOS' ]]; then
     echo ======================================
     osascript \
         -e "tell application \"Terminal\" to activate" \
+        -e "tell application \"Terminal\" to set bounds of front window to {500, 200, 1700, 750}" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"cd $(PWD)\" in selected tab of the front window" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"chmod +x *.sh\" in selected tab of the front window" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_service_discovery.sh\" in selected tab of the front window" \
-        -e "${injectScript_new_tab}" \
-        -e "${injectScript_delay}" \
-        -e "${injectScript_start_config_service}" \
+        -e "${injectCmd_new_tab}" \
+        -e "${injectCmd_delay}" \
+        -e "${injectCmd_start_config_service}" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_pms.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_engine.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_gateway.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_ec.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_event_logger.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_gui.sh\" in selected tab of the front window" \
         -e "tell application \"System Events\" to keystroke \"t\" using {command down}" \
-        -e "delay 0.07" \
+        -e "${injectCmd_delay}" \
         -e "tell application \"Terminal\" to do script \"./start_mpf.sh\" in selected tab of the front window"
     echo All services have been executed!
     echo Check Terminal window and tabs for different services.


### PR DESCRIPTION
resolves #57 

**DONE:**
As @mwageneder had problems with executing the `start.sh` script on his MBP, we found out that the zsh shell is causing the problem. Further investigations led to the conclusion, that the `zsh` shell needs extra time to be initialized in every new tab. Thus, the support for the `zsh` shell is dropped as it would take too long and it would be still not reliable. (Tested it multiple times with the zsh shell and by increasing the delays between the commands)

Therefore the following things have been done:
- added note in readme for `zsh` users to change to `bash` and how to do this.
- also added note that the `zsh` shell is not recommended at all
- `start.sh` was modified and dynamic variables are used now in applescript for delays.
- argument parser was modified and the `dev mode` argument has changed. This was also changed in the README.
- the custom applescript in the start.sh does not work well with zsh as delays are too short and else it takes too long to execute. Therefore, support is dropped.

**ToDo:**
- @mwageneder just take this into consideration and please confirm. If you still want support for `zsh` I would kindly ask for a comment in this PR and why. If you agree with the solution, please approve.
- @tortmann 2nd person for approval needed. 