### PR TITLE
Changed the Spring Cloud Config to use local config

### DIFF
--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/event-logger.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/event-logger.properties
@@ -1,0 +1,19 @@
+server.port=0
+eureka.instance.instance-id=${spring.application.name}:${vcap.application.instance_id:${spring.application.instance_id:${random.value}}}
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=event_logger.log
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ippr_event_logger?useSSL=false&createDatabaseIfNotExist=true
+spring.datasource.username=ippr
+spring.datasource.password=Pa$$w0rd
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/external-communicator.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/external-communicator.properties
@@ -1,0 +1,22 @@
+eureka.instance.instance-id=${spring.application.name}:${vcap.application.instance_id:${spring.application.instance_id:${random.value}}}
+
+server.port=0
+
+rest.inbound.json=json
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=external_communicator.log
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ippr_communicator?useSSL=false&createDatabaseIfNotExist=true
+spring.datasource.username=ippr
+spring.datasource.password=Pa$$w0rd
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/gateway.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/gateway.properties
@@ -1,0 +1,21 @@
+server.port=${port:10000}
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=gateway.log
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ippr_security?useSSL=false
+spring.datasource.username=ippr
+spring.datasource.password=Pa$$w0rd
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
+# Strategy for login
+rbac.system.service=memory
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/gateway.yml
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/gateway.yml
@@ -1,0 +1,8 @@
+zuul:
+  routes:
+    external-communicator:
+      path: /ec/**
+      serviceId: external-communicator
+    event-logger:
+      path: /ev/**
+      serviceId: event-logger

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/process-engine.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/process-engine.properties
@@ -1,0 +1,20 @@
+server.port=0
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=process_engine.log
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ippr?useSSL=false
+spring.datasource.username=ippr
+spring.datasource.password=Pa$$w0rd
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.generate-ddl=false
+spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF
+
+event.logger.send=false

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/process-model-storage.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/process-model-storage.properties
@@ -1,0 +1,21 @@
+server.port=0
+
+ippr.insert-examples.enabled=false
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=process_model_storage.log
+
+spring.datasource.url=jdbc:mysql://localhost:3306/ippr?useSSL=false
+spring.datasource.username=ippr
+spring.datasource.password=Pa$$w0rd
+spring.jpa.show-sql=false
+#spring.jpa.hibernate.ddl-auto=update
+ spring.jpa.hibernate.ddl-auto=update
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.naming.strategy=org.hibernate.cfg.ImprovedNamingStrategy
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF

--- a/ConfigurationService/src/main/resources/EBUSA-AIM17-config/service-discovery.properties
+++ b/ConfigurationService/src/main/resources/EBUSA-AIM17-config/service-discovery.properties
@@ -1,0 +1,12 @@
+server.port=8761
+
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF
+
+logging.level.at.fhjoanneum=DEBUG
+logging.level.org.hibernate = ERROR
+
+logging.file=service_discovery.log

--- a/ConfigurationService/src/main/resources/application.properties
+++ b/ConfigurationService/src/main/resources/application.properties
@@ -1,3 +1,9 @@
 server.port=8888
 
-spring.cloud.config.server.git.uri=https://github.com/stefanstaniAIM/IPPR2016-config
+# This configuration parameter takes a URI which points to a repository where all configuration files are located
+# It can be a GitHub (or equivalent) repository, or a local repository
+# More informaiton can be found here: https://cloud.spring.io/spring-cloud-config
+
+# spring.cloud.config.server.git.uri=https://github.com/stefanstaniAIM/IPPR2016-config
+spring.profiles.active=native
+spring.cloud.config.server.native.search-locations= classpath:EBUSA-AIM17-config/


### PR DESCRIPTION
resolves #38 

**INFORMATION:**
- `Sring Cloud Config` takes configuration for all services and distributes them
- The old way it uses a git repository which is not under our control and therefore this task was created.
- Changed the configuration of the `Spring Cloud Config` to use local configuration files which reside in the repo
- It is possible to move the local config again to a separate GH-repository (if ever needed)
- Tested it and the `ConfigurationService` is running without any problems
  - Also tested it with all other services running simultaneously. No problems detected.

> Further information about the Spring Cloud Config can be found here: https://cloud.spring.io/spring-cloud-config/

**ToDo:**
- More or less nothing much. It has been tested and it works.
- Just need a feedback if we should document it (in the README for example) or if we should refer to this PR if we have any issues in the future regarding this topic?