### PR TITLE
Store service #30

### DIFF
--- a/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/controller/ProcessStoreGatewayController.java
+++ b/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/controller/ProcessStoreGatewayController.java
@@ -1,6 +1,7 @@
 package at.fhjoanneum.ippr.gateway.api.controller;
 
 import at.fhjoanneum.ippr.commons.dto.processstore.ProcessStoreDTO;
+import at.fhjoanneum.ippr.gateway.api.controller.user.HttpHeaderUser;
 import at.fhjoanneum.ippr.gateway.api.services.impl.ProcessStoreCallerImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.net.URISyntaxException;
 import java.util.concurrent.Callable;
 
 @RestController
@@ -27,4 +29,75 @@ public class ProcessStoreGatewayController {
             return processStoreCaller.findAllProcesses().get();
         };
     }
+
+    @RequestMapping(value = "api/store/processes/approved", method = RequestMethod.GET)
+    public @ResponseBody Callable<ResponseEntity<ProcessStoreDTO[]>> findAllApprovedProcesses(
+            final HttpServletRequest request) {
+        return() -> {
+            return processStoreCaller.findAllApprovedProcesses().get();
+        };
+    }
+
+    @RequestMapping(value = "api/store/processes/notApproved", method = RequestMethod.GET)
+    public @ResponseBody Callable<ResponseEntity<ProcessStoreDTO[]>> findAllNotApprovedProcesses(
+            final HttpServletRequest request) {
+        return() -> {
+            return processStoreCaller.findAllNotApprovedProcesses().get();
+        };
+    }
+
+    @RequestMapping(value ="api/store/process/{processId}", method = RequestMethod.GET)
+    public @ResponseBody Callable<ProcessStoreDTO> findProcessById(
+            final HttpServletRequest request,
+            @PathVariable(name = "processId") final Long processId) {
+        return() -> {
+            return processStoreCaller.findProcessById(processId).get();
+        };
+    }
+
+    @RequestMapping(value ="api/store/process/{processId}/approve", method = RequestMethod.POST)
+    public void approveProcessById(@PathVariable(name = "processId") final Long processId) {
+        final Runnable runnable = () -> {
+            try {
+                processStoreCaller.approveProcessesById(processId);
+            } catch (final URISyntaxException e) {
+                LOG.error(e.getMessage());
+            }
+        };
+        runnable.run();
+    }
+
+    @RequestMapping(value ="api/store/process/{processId}/unapprove", method = RequestMethod.POST)
+    public void unapproveProcessById(@PathVariable(name = "processId") final Long processId) {
+        final Runnable runnable = () -> {
+            try {
+                processStoreCaller.unapproveProcessesById(processId);
+            } catch (final URISyntaxException e) {
+                LOG.error(e.getMessage());
+            }
+        };
+        runnable.run();
+    }
+
+    @RequestMapping(value ="api/store/processes/byUser/{userId}", method = RequestMethod.GET)
+    public @ResponseBody Callable<ResponseEntity<ProcessStoreDTO[]>> findProcessByUserId(
+            final HttpServletRequest request,
+            @PathVariable(name = "userId") final Long userId) {
+        return() -> {
+            final HttpHeaderUser headerUser = new HttpHeaderUser(request);
+            return processStoreCaller.findAllProcessesByUserId(headerUser, userId).get();
+        };
+    }
+
+    /*@RequestMapping(value ="api/store/process/upload", method = RequestMethod.POST)
+    @ResponseBody
+    public void uploadProcess(
+            final HttpServletRequest request,
+            @RequestParam() processCreator
+            ){
+        return() -> {
+            final HttpHeaderUser headerUser = new HttpHeaderUser(request);
+            return processStoreCaller.uploadProcess().get();
+        };
+    }*/
 }

--- a/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/controller/user/HttpHeaderUser.java
+++ b/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/controller/user/HttpHeaderUser.java
@@ -18,10 +18,12 @@ public class HttpHeaderUser {
 
   private static final String CLAIM_ID = "claims";
   private static final String USER_ID = "userId";
+  private static final String ORGANIZATION_ID = "organizationId";
   private static final String ROLES_ID = "roles";
   private static final String RULES_ID = "rules";
 
   private final String userId;
+  private final String organizationId;
   private final String roles;
   private final String rules;
 
@@ -33,15 +35,21 @@ public class HttpHeaderUser {
     Preconditions.checkNotNull(claims.get(RULES_ID));
 
     final String userId = String.valueOf(claims.get(USER_ID));
+    final String organizationId = String.valueOf(claims.get(ORGANIZATION_ID));
     final String roles = StringUtils.join((List<String>) claims.get(ROLES_ID), ",");
     final String rules = StringUtils.join((List<String>) claims.get(RULES_ID), ",");
     this.userId = userId;
+    this.organizationId = organizationId;
     this.roles = roles;
     this.rules = rules;
   }
 
   public String getUserId() {
     return userId;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
   }
 
   public String getRoles() {
@@ -55,6 +63,7 @@ public class HttpHeaderUser {
   public HttpHeaders getHttpHeaders() {
     final HttpHeaders headers = new HttpHeaders();
     headers.add(USER_ID, userId);
+    headers.add(ORGANIZATION_ID, organizationId);
     headers.add(ROLES_ID, roles);
     headers.add(RULES_ID, rules);
     return headers;

--- a/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/services/impl/ProcessStoreCallerImpl.java
+++ b/Gateway/src/main/java/at/fhjoanneum/ippr/gateway/api/services/impl/ProcessStoreCallerImpl.java
@@ -2,6 +2,7 @@ package at.fhjoanneum.ippr.gateway.api.services.impl;
 
 import at.fhjoanneum.ippr.commons.dto.processstore.ProcessStoreDTO;
 import at.fhjoanneum.ippr.gateway.api.config.GatewayConfig;
+import at.fhjoanneum.ippr.gateway.api.controller.user.HttpHeaderUser;
 import at.fhjoanneum.ippr.gateway.api.services.Caller;
 import at.fhjoanneum.ippr.gateway.security.repositories.RBACRepository;
 import org.apache.http.client.utils.URIBuilder;
@@ -10,13 +11,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.net.URISyntaxException;
-import java.util.BitSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 @Service
@@ -34,7 +38,70 @@ public class ProcessStoreCallerImpl implements Caller {
     @Async
     public Future<ResponseEntity<ProcessStoreDTO[]>> findAllProcesses() throws URISyntaxException {
         final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/processes");
-
         return createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO[].class, null);
+    }
+
+    @Async
+    public Future<ResponseEntity<ProcessStoreDTO[]>> findAllApprovedProcesses() throws URISyntaxException {
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/processes/approved");
+        return createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO[].class, null);
+    }
+
+    @Async
+    public Future<ResponseEntity<ProcessStoreDTO[]>> findAllNotApprovedProcesses() throws URISyntaxException {
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/processes/notApproved");
+        return createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO[].class, null);
+    }
+
+    @Async
+    public Future<ProcessStoreDTO> findProcessById(Long processId) throws URISyntaxException {
+        final CompletableFuture<ProcessStoreDTO> future = new CompletableFuture<>();
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/process/"+processId);
+
+        final ListenableFuture<ResponseEntity<ProcessStoreDTO>> responseFuture =
+                createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO.class, null);
+
+        responseFuture.addCallback(result -> {
+            future.complete(result.getBody());
+        }, error -> {
+            future.completeExceptionally(error);
+        });
+
+        return future;
+    }
+
+    @Async
+    public void approveProcessesById(Long processId) throws URISyntaxException {
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/process/"+processId+"/approve");
+        createRequest(uri, HttpMethod.POST, null, ProcessStoreDTO.class, null);
+    }
+
+    @Async
+    public void unapproveProcessesById(Long processId) throws URISyntaxException {
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/process/"+processId+"/unapprove");
+        createRequest(uri, HttpMethod.POST, null, ProcessStoreDTO.class, null);
+    }
+
+    @Async
+    public Future<ResponseEntity<ProcessStoreDTO[]>> findAllProcessesByUserId(
+            final HttpHeaderUser headerUser, final Long userId
+            ) throws URISyntaxException {
+
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/processes/byUser/"+userId);
+        final HttpHeaders header = headerUser.getHttpHeaders();
+        return createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO[].class, header);
+
+    }
+
+    @Async
+    public Future<ResponseEntity<ProcessStoreDTO[]>> uploadProcess(
+            final HttpHeaderUser headerUser, final Long userId
+    ) throws URISyntaxException {
+
+        final URIBuilder uri = new URIBuilder(gatewayConfig.getProcessStoreAddress()).setPath("/process/upload");
+        final HttpHeaders header = headerUser.getHttpHeaders();
+
+        return createRequest(uri, HttpMethod.GET, null, ProcessStoreDTO[].class, header);
+
     }
 }

--- a/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/controller/ProcessStoreController.java
+++ b/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/controller/ProcessStoreController.java
@@ -5,12 +5,10 @@ import at.fhjoanneum.ippr.processstore.services.ProcessStoreService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -27,4 +25,54 @@ public class ProcessStoreController {
     public @ResponseBody Callable<List<ProcessStoreDTO>> getAllProcesses(final HttpServletRequest request) {
         return() -> processStoreService.findAllProcesses().get();
     }
+
+
+    @RequestMapping(value = "processes/byUser/{userId}", method = RequestMethod.GET)
+    public @ResponseBody Callable<List<ProcessStoreDTO>> getProcessByUserId(
+            final HttpServletRequest request, @PathVariable("userId") final String userId) {
+        return() -> processStoreService.findAllProcessesByUserId(userId).get();
+    }
+
+    @RequestMapping(value = "processes/{organisationId}", method = RequestMethod.GET)
+    public @ResponseBody Callable<List<ProcessStoreDTO>> getProcessByOrganisationId(
+            final HttpServletRequest request, @PathVariable("organisationId") final String organisationId) {
+        return() -> processStoreService.findAllProcessesByOrganisationId(organisationId).get();
+    }
+
+    @RequestMapping(value = "processes/approved", method = RequestMethod.GET)
+    public @ResponseBody Callable<List<ProcessStoreDTO>> getAllApprovedProcesses(final HttpServletRequest request) {
+        return() -> processStoreService.findAllApprovedProcesses().get();
+    }
+
+    @RequestMapping(value = "processes/notApproved", method = RequestMethod.GET)
+    public @ResponseBody Callable<List<ProcessStoreDTO>> getAllNotApprovedProcesses(final HttpServletRequest request) {
+        return() -> processStoreService.findAllNotApprovedProcesses().get();
+    }
+
+    @PostMapping(value = "process/upload")
+    @ResponseBody
+    public void uploadProcess(final HttpServletRequest request, String processName, String processDescription, String processCreator,
+                                                         Date processCreatedAt, Long processVersion, Double processPrice) {
+        processStoreService.saveProcessStoreObject(processName, processDescription,processCreator,
+                processCreatedAt,processVersion,processPrice);
+    }
+
+    @RequestMapping(value = "process/{processId}", method = RequestMethod.GET)
+    public @ResponseBody Callable<ProcessStoreDTO> getProcessById(
+            final HttpServletRequest request, @PathVariable("processId") final Long processId) {
+        return() -> processStoreService.findProcessById(processId).get();
+    }
+
+    @RequestMapping(value = "process/{processId}/approve", method = RequestMethod.POST)
+    public @ResponseBody Callable<ProcessStoreDTO> approveProcessById(
+            final HttpServletRequest request, @PathVariable("processId") final Long processId) {
+        return() -> processStoreService.changeApprovedState(true ,processId).get();
+    }
+
+    @RequestMapping(value = "process/{processId}/unapprove", method = RequestMethod.POST)
+    public @ResponseBody Callable<ProcessStoreDTO> unapproveProcessById(
+            final HttpServletRequest request, @PathVariable("processId") final Long processId) {
+        return() -> processStoreService.changeApprovedState(false ,processId).get();
+    }
+
 }

--- a/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/persistence/entities/ProcessStoreBuilder.java
+++ b/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/persistence/entities/ProcessStoreBuilder.java
@@ -17,23 +17,29 @@ public class ProcessStoreBuilder implements Builder<ProcessStoreObject> {
     private Date processCreatedAt;
     private Long processVersion;
     private Double processPrice;
+    private String processApprover;
+    private String processApproverComment;
+    private boolean isApproved = false;
+    private Date processApprovedDate;
 
-    public ProcessStoreBuilder processName(final String processName, String processDescription, String processCreator,
-                                           Date processCreatedAt, Long processVersion, Double processPrice){
+    public ProcessStoreBuilder(String processName, String processDescription, String processCreator, Date processCreatedAt, Long processVersion, Double processPrice, String processApprover, String processApproverComment, boolean isApproved, Date processApprovedDate) {
         checkArgument(StringUtils.isNotBlank(processName));
         checkArgument(StringUtils.isNotBlank(processDescription));
         checkArgument(StringUtils.isNotBlank(processCreator));
         checkNotNull(processCreatedAt);
         checkNotNull(processVersion);
         checkNotNull(processPrice);
+        checkNotNull(isApproved);
         this.processName = processName;
         this.processDescription = processDescription;
         this.processCreator = processCreator;
         this.processCreatedAt = processCreatedAt;
         this.processVersion = processVersion;
         this.processPrice = processPrice;
-
-        return this;
+        this.processApprover = processApprover;
+        this.processApproverComment = processApproverComment;
+        this.isApproved = isApproved;
+        this.processApprovedDate = processApprovedDate;
     }
 
     @Override
@@ -44,8 +50,9 @@ public class ProcessStoreBuilder implements Builder<ProcessStoreObject> {
         checkNotNull(processCreatedAt);
         checkNotNull(processVersion);
         checkNotNull(processPrice);
+        checkNotNull(isApproved);
 
         return new ProcessStoreObjectImpl(processName, processDescription, processCreator, processCreatedAt,
-                processVersion, processPrice);
+                processVersion, processPrice, processApprover, processApproverComment, isApproved, processApprovedDate);
     }
 }

--- a/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/persistence/entities/ProcessStoreObjectImpl.java
+++ b/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/persistence/entities/ProcessStoreObjectImpl.java
@@ -39,10 +39,32 @@ public class ProcessStoreObjectImpl implements ProcessStoreObject {
     @NotBlank
     private Double processPrice;
 
+    @Column
+    private String processApprover;
+
+    @Column
+    private String processApproverComment;
+
+    @Column(nullable = false)
+    private boolean isApproved;
+
+    @Column
+    private Date processApprovedDate;
+
 
     public ProcessStoreObjectImpl() {}
 
-    public ProcessStoreObjectImpl(String processName, String processDescription, String processCreator, Date processCreatedAt, Long processVersion, Double processPrice) {
+    public ProcessStoreObjectImpl(String processName, String processDescription, String processCreator, Date processCreatedAt, Long processVersion, Double processPrice, String processApprover, String processApproverComment, boolean isApproved, Date processApprovedDate) {
+        this.processName = processName;
+        this.processDescription = processDescription;
+        this.processCreator = processCreator;
+        this.processCreatedAt = processCreatedAt;
+        this.processVersion = processVersion;
+        this.processPrice = processPrice;
+        this.processApprover = processApprover;
+        this.processApproverComment = processApproverComment;
+        this.isApproved = isApproved;
+        this.processApprovedDate = processApprovedDate;
     }
 
     @Override
@@ -98,5 +120,37 @@ public class ProcessStoreObjectImpl implements ProcessStoreObject {
 
     public void setProcessPrice(Double processPrice) {
         this.processPrice = processPrice;
+    }
+
+    public String getProcessApprover() {
+        return processApprover;
+    }
+
+    public void setProcessApprover(String processApprover) {
+        this.processApprover = processApprover;
+    }
+
+    public String getProcessApproverComment() {
+        return processApproverComment;
+    }
+
+    public void setProcessApproverComment(String processApproverComment) {
+        this.processApproverComment = processApproverComment;
+    }
+
+    public boolean isApproved() {
+        return isApproved;
+    }
+
+    public void setApproved(boolean approved) {
+        isApproved = approved;
+    }
+
+    public Date getProcessApprovedDate() {
+        return processApprovedDate;
+    }
+
+    public void setProcessApprovedDate(Date processApprovedDate) {
+        this.processApprovedDate = processApprovedDate;
     }
 }

--- a/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/repositories/ProcessStore.java
+++ b/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/repositories/ProcessStore.java
@@ -1,10 +1,13 @@
 package at.fhjoanneum.ippr.processstore.repositories;
 
 import at.fhjoanneum.ippr.processstore.persistence.entities.ProcessStoreObjectImpl;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
 import java.util.List;
 
 @Repository
@@ -13,7 +16,25 @@ public interface ProcessStore extends CrudRepository<ProcessStoreObjectImpl, Lon
     @Query(value = "SELECT * FROM processstore", nativeQuery = true)
     public List<ProcessStoreObjectImpl> findAllProcesses();
 
-    @Query(value="SELECT * FROM processstore", nativeQuery = true)
-    public ProcessStoreObjectImpl findProcessWithId(Long processId);
+    @Query(value="SELECT * FROM processstore ps WHERE ps.process_id = :process_id", nativeQuery = true)
+    public ProcessStoreObjectImpl findProcessById(@Param("process_id") Long processId);
+
+    @Query(value="SELECT * FROM processstore ps WHERE ps.process_creator = :user_id", nativeQuery = true)
+    public List<ProcessStoreObjectImpl> findAllProcessesByUserId(@Param("user_id") String processCreator);
+
+    // No idea atm how to handle this case
+    @Query(value="SELECT * FROM processstore ps WHERE ps.process_creator = :user_id", nativeQuery = true)
+    public ProcessStoreObjectImpl findAllProcessesByOrganisationId(@Param("user_id") String processCreator);
+
+    @Query(value="SELECT * FROM processstore ps WHERE ps.is_approved = :is_approved", nativeQuery = true)
+    public List<ProcessStoreObjectImpl> findAllProcesses(@Param("is_approved") boolean isApproved);
+
+    @Modifying
+    @Query(value="UPDATE processstore ps SET ps.is_approved = ?1 WHERE ps.process_id = ?2", nativeQuery = true)
+    public int changeApprovedState(boolean isApproved, Long processId);
+
+    //@Param("approved_date") Date approvedDate,
+    //@Param("approver_id") String approverId,
+    //@Param("approver_comment") String approverComment,
 
 }

--- a/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/services/ProcessStoreService.java
+++ b/ProcessStore/src/main/java/at/fhjoanneum/ippr/processstore/services/ProcessStoreService.java
@@ -2,13 +2,27 @@ package at.fhjoanneum.ippr.processstore.services;
 
 import at.fhjoanneum.ippr.commons.dto.processstore.ProcessStoreDTO;
 
+import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Future;
 
 public interface ProcessStoreService {
 
     Future<List<ProcessStoreDTO>> findAllProcesses();
 
-    Optional<ProcessStoreDTO> saveProcessStoreObject(String processName);
+    Future<ProcessStoreDTO> findProcessById(Long processId);
+
+    Future<List<ProcessStoreDTO>> findAllApprovedProcesses();
+
+    Future<List<ProcessStoreDTO>> findAllNotApprovedProcesses();
+
+    Future<ProcessStoreDTO> changeApprovedState(boolean isApproved, Long processId);
+
+    Future<List<ProcessStoreDTO>> findAllProcessesByUserId(String userId);
+
+    Future<List<ProcessStoreDTO>> findAllProcessesByOrganisationId(String organisationId);
+
+    void saveProcessStoreObject(String processName, String processDescription, String processCreator,
+                                Date processCreatedAt, Long processVersion, Double processPrice);
+
 }

--- a/SpringCommons/src/main/java/at/fhjoanneum/ippr/commons/dto/processstore/ProcessStoreDTO.java
+++ b/SpringCommons/src/main/java/at/fhjoanneum/ippr/commons/dto/processstore/ProcessStoreDTO.java
@@ -7,7 +7,7 @@ import java.util.Date;
 @XmlRootElement
 public class ProcessStoreDTO implements Serializable {
 
-    //private static final long serialVersionUID = 2075853829794256949L;
+    private static final long serialVersionUID = 2075853829794256949L;
 
     private Long processId;
 
@@ -17,12 +17,14 @@ public class ProcessStoreDTO implements Serializable {
     private Date processCreatedAt;
     private Long processVersion;
     private Double processPrice;
+    private String processApprover;
+    private String processApproverComment;
+    private boolean isApproved;
+    private Date processApprovedDate;
 
     public ProcessStoreDTO() {}
 
-    public ProcessStoreDTO(final Long processId, final String processName, final String processDescription,
-                           final String processCreator, final Date processCreatedAt, final Long processVersion,
-                           final Double processPrice) {
+    public ProcessStoreDTO(final Long processId, final String processName, final String processDescription, final String processCreator, final Date processCreatedAt, final Long processVersion, final Double processPrice, final String processApprover, final String processApproverComment, final boolean isApproved, final Date processApprovedDate) {
         this.processId = processId;
         this.processName = processName;
         this.processDescription = processDescription;
@@ -30,7 +32,10 @@ public class ProcessStoreDTO implements Serializable {
         this.processCreatedAt = processCreatedAt;
         this.processVersion = processVersion;
         this.processPrice = processPrice;
-
+        this.processApprover = processApprover;
+        this.processApproverComment = processApproverComment;
+        this.isApproved = isApproved;
+        this.processApprovedDate = processApprovedDate;
     }
 
     public Long getProcessId() { return processId; }
@@ -55,5 +60,21 @@ public class ProcessStoreDTO implements Serializable {
 
     public Double getProcessPrice() {
         return processPrice;
+    }
+
+    public String getProcessApprover() {
+        return processApprover;
+    }
+
+    public String getProcessApproverComment() {
+        return processApproverComment;
+    }
+
+    public boolean isApproved() {
+        return isApproved;
+    }
+
+    public Date getProcessApprovedDate() {
+        return processApprovedDate;
     }
 }


### PR DESCRIPTION
WIP Changes to ProcessStore Service

## ProcessStore Repo
Added approver columns are now stored within the ProcessStore table, modified ProcessStoreDTO. `is_approved` is `false` by default.
```
{
        "processId": 1,
        "processName": "name1",
        "processDescription": "test desct asldfasd",
        "processCreator": "test1",
        "processCreatedAt": 993052800000,
        "processVersion": 1,
        "processPrice": 123.123,
        "processApprover": "approver1",
        "processApproverComment": "well done approved",
        "processApprovedDate": 1213977600000,
        "approved": false
}
```
## TestData
```
INSERT INTO ippr_store.processstore 
VALUES (1, true,'08.06.2018','approver1','well done approved','01.06.2018', 'test1', 'test desct asldfasd', 'name1', 123.123, 1);
INSERT INTO ippr_store.processstore 
VALUES (2, false, null,null,null, '20.06.2018', 't1231est', 'testasdas asda as asd as ad asd ad asd ad asd dd', 'name2', 222.222, 2);
INSERT INTO ippr_store.processstore 
VALUES (3, false, '09.06.2018','approver1','error', '20.06.2018', 'test3', 'testprocess nummer 3', 'name2', 222.222, 2);
```

## Endpoints
At the moment the following endpoints are available
- `GET localhost:10000/api/store/processes` - returns a list with all processes from store
- `GET localhost:10000/api/store/processes/approved` - returns a list with all approved processes from store
- `GET localhost:10000/api/store/processes/notApproved` - returns a list with all unapproved processes from store
- `GET localhost:10000/api/store/process/{processId}` - returns process with `{processid}`
- `POST localhost:10000/api/store/process/{processId}/approve` - approve process with `{processid}`
- `POST localhost:10000/api/store/process/{processId}/unapprove` - unapprove process with `{processid}`

## ToDo
- insertStatements for ProcessStore
- update/modify Statement for ApproverComments etc
- add RatingRepo to ProcessStore
- add RatingEndpoints