### PR TITLE
mysql-docker fix & start script addition

### DIFF
--- a/Setup/mysql_docker/DB_setup.sql
+++ b/Setup/mysql_docker/DB_setup.sql
@@ -1,11 +1,12 @@
 -- Create databases which are not automatically created out of the code
 CREATE DATABASE ippr;
 CREATE DATABASE ippr_security;
+CREATE DATABASE ippr_store;
 
 -- Create User for the services to access the DB
-CREATE USER 'ippr'@'localhost' IDENTIFIED BY 'Pa$$w0rd';
+CREATE USER 'ippr'@'localhost' IDENTIFIED WITH mysql_native_password BY 'Pa$$w0rd';
 GRANT ALL PRIVILEGES ON * . * TO 'ippr'@'localhost';
-CREATE USER 'ippr'@'%' IDENTIFIED BY 'Pa$$w0rd';
+CREATE USER 'ippr'@'%' IDENTIFIED WITH mysql_native_password BY 'Pa$$w0rd';
 GRANT ALL PRIVILEGES ON * . * TO 'ippr'@'%';
 FLUSH PRIVILEGES;
 

--- a/Setup/mysql_docker/Dockerfile
+++ b/Setup/mysql_docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM mysql:latest
-MAINTAINER Bajric (amar.bajric@edu.fh-joanneum.at)
+FROM mysql:5.7
+MAINTAINER Amar Bajric (amar.bajric@edu.fh-joanneum.at)
 ENV MYSQL_ROOT_PASSWORD="Pa$$w0rd"
 RUN apt-get update
 # check https://hub.docker.com/_/mysql/ for more info about this directory

--- a/Setup/start_unix/start.sh
+++ b/Setup/start_unix/start.sh
@@ -80,7 +80,7 @@ elif [[ "$OS" == 'macOS' ]]; then
     echo ======================================
     echo Tab2 - ServiceDiscovery && echo ${info_log_cfg_service} && echo Tab4 - ProcessModelStorage \
     && echo Tab5 - ProcessEngine && echo Tab6 - Gateway && echo Tab7 - ExternalCommunicator && echo Tab8 - EventLogger \
-    && echo Tab9 - GUI && echo Tab10 - Modelling Platform
+    && echo Tab9 - ProcessStore && echo Tab10 - GUI && echo Tab11 - Modelling Platform
     echo ======================================
     osascript \
         -e "tell application \"Terminal\" to activate" \


### PR DESCRIPTION
resolves #78 

**Done**
- `db_setup.sql` file where identification is explicitly set to mysql_native_password
- `Dockerfile` now uses mysql version 5.7 explicitly instead of latest as the latest (i.e. 8.x) causes problems with the password algorithm (new sha algo is used now)
- `start.sh` script for unix based systems fixed
  - macOS now shows in which tab the process-store is running